### PR TITLE
send event to datadog on release failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,16 +21,7 @@ on:
         required: true
 
 jobs:
-  fail_on_purpose:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail on purpose
-        run: |
-          echo "This is a test failure"
-          exit 1
-
   goreleaser:
-    needs: [fail_on_purpose]
     runs-on: macos-latest
     steps:
       - name: Checkout caller repo
@@ -87,7 +78,6 @@ jobs:
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
 
   goreleaser-docker:
-    needs: [fail_on_purpose]
     permissions:
       id-token: write
       contents: read
@@ -171,7 +161,7 @@ jobs:
           cat "$TMPFILE"
 
   notify-failure:
-    needs: [fail_on_purpose, goreleaser, goreleaser-docker, record-release]
+    needs: [goreleaser, goreleaser-docker, record-release]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
       APPLE_SIGNING_KEY_P12_PASSWORD: ${{ secrets.APPLE_SIGNING_KEY_P12_PASSWORD }}
       AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
       AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 ```
 
 2. Ensure your repository has the following secrets configured:
@@ -49,6 +50,7 @@ jobs:
    - `APPLE_SIGNING_KEY_P12_PASSWORD`: Password for the Apple signing key
    - `AC_PASSWORD`: Apple Connect password
    - `AC_PROVIDER`: Apple Connect provider
+   - `DATADOG_API_KEY`: Datadog API key for monitoring releases
 
 3. Remove all GoReleaser and gon files from your repository, if they were previously created there.
 
@@ -81,4 +83,4 @@ The workflows are versioned using Git tags. When testing a new version of the wo
 uses: ConductorOne/github-workflows/.github/workflows/release.yaml@my-branch
 ```
 
-Github does not resolve semantic versioning - tags must match exactly.  The major version must _float_.
+Github does not resolve semantic versioning - tags must match exactly. The major version must _float_.


### PR DESCRIPTION
update the shared release workflow to notify datadog on failure

![Screenshot 2025-06-16 at 15 55 53](https://github.com/user-attachments/assets/59ccace5-fbc6-4d75-b912-19b2c0a9e79c)
