### PR TITLE
lambda release success dependent on goreleaser assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,7 +171,7 @@ jobs:
 
   record-lambda-release:
     if: inputs.lambda == true
-    needs: [goreleaser-docker]
+    needs: [goreleaser, goreleaser-docker] # lambda releases are dependent on github release assets in the goreleaser job
     permissions:
       id-token: write
       contents: read
@@ -235,7 +235,7 @@ jobs:
           rm -f "$TMPFILE"
 
   notify-lambda-failure:
-    needs: [goreleaser-docker, record-lambda-release]
+    needs: [goreleaser, goreleaser-docker, record-lambda-release]
     if: failure() && inputs.lambda == true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
we have to wait for the `goreleaser` job to complete as well, before recording the lambda release, since the lambda release build needs the github release assets to be available for when building the release metadata in the `ConnectorReleases`.