### PR TITLE
Pass GitHub release timestamp to RecordRelease API

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1311,13 +1311,17 @@ jobs:
             core.setSecret(token)
             core.setOutput('token', token)
 
-      - name: Fetch release notes for changelog
+      - name: Fetch release metadata
+        id: release-meta
         if: steps.registry-oidc.outcome == 'success'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}" --jq .body > /tmp/changelog.md || true
+          RELEASE_JSON=$(gh api "repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}" 2>/dev/null || echo '{}')
+          echo "$RELEASE_JSON" | jq -r '.body // empty' > /tmp/changelog.md || true
+          CREATED_AT=$(echo "$RELEASE_JSON" | jq -r '.created_at // empty')
+          echo "released_at=$CREATED_AT" >> "$GITHUB_OUTPUT"
 
       - name: Write merged manifest from dist recording job
         working-directory: _workflows
@@ -1353,6 +1357,11 @@ jobs:
             CAPABILITIES_FLAG="-capabilities ../_connector/baton_capabilities.json"
           fi
 
+          RELEASED_AT_FLAG=""
+          if [ -n "${{ steps.release-meta.outputs.released_at }}" ]; then
+            RELEASED_AT_FLAG="-released-at ${{ steps.release-meta.outputs.released_at }}"
+          fi
+
           go run ./cmd/record-release \
             -manifest _output/manifest.json \
             -org "${{ github.event.repository.owner.login }}" \
@@ -1365,7 +1374,8 @@ jobs:
             $DOCS_FLAG \
             $CHANGELOG_FLAG \
             $CONFIG_SCHEMA_FLAG \
-            $CAPABILITIES_FLAG
+            $CAPABILITIES_FLAG \
+            $RELEASED_AT_FLAG
 
   verify-release:
     # Verify release artifacts and attestations after publishing

--- a/cmd/record-release/main.go
+++ b/cmd/record-release/main.go
@@ -33,6 +33,7 @@ type RecordReleaseRequest struct {
 	CertificateURL string                   `json:"certificateUrl,omitempty"`
 	Assets         map[string]*ReleaseAsset `json:"assets,omitempty"`
 	Images         map[string]*ReleaseImage `json:"images,omitempty"`
+	ReleasedAt     string                   `json:"releasedAt,omitempty"`
 }
 
 // ReleaseAsset is the transformed asset for the registry API.
@@ -97,6 +98,8 @@ func main() {
 	flag.StringVar(&changelogPath, "changelog", "", "Path to a file containing release notes (optional)")
 	flag.StringVar(&configSchemaPath, "config-schema", "", "Path to config_schema.json file (optional)")
 	flag.StringVar(&capabilitiesPath, "capabilities", "", "Path to baton_capabilities.json file (optional)")
+	var releasedAt string
+	flag.StringVar(&releasedAt, "released-at", "", "Release creation timestamp in RFC 3339 format (optional, defaults to server time)")
 	flag.StringVar(&token, "token", "", "Bearer token (or set REGISTRY_API_TOKEN env var)")
 	flag.Parse()
 
@@ -245,6 +248,7 @@ func main() {
 		CertificateURL: manifest.GetCertificateHref(),
 		Assets:         assets,
 		Images:         images,
+		ReleasedAt:     releasedAt,
 	}
 
 	bodyBytes, err := json.Marshal(req)


### PR DESCRIPTION
## Why

RecordRelease currently uses server `time.Now()` as `releasedAt`, which is ~35 minutes after the actual GitHub release creation. This causes timestamp drift between what dist.conductorone.com shows and what the registry records.

## What this changes

- Fetches `created_at` from the GitHub release API in the release workflow
- Passes it to `record-release` via new `-released-at` flag
- The registry API accepts this as an optional `released_at` field (falls back to server time if not provided)

Depends on: ductone/connector-registry-api#61