### PR TITLE
fix: use published_at for registry released_at timestamp

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1320,6 +1320,8 @@ jobs:
         run: |
           RELEASE_JSON=$(gh api "repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}" 2>/dev/null || echo '{}')
           echo "$RELEASE_JSON" | jq -r '.body // empty' > /tmp/changelog.md || true
+          # Prefer publish time; created_at can predate visibility for draft releases
+          # and for normal create-then-publish workflow runs.
           RELEASED_AT=$(echo "$RELEASE_JSON" | jq -r '.published_at // .created_at // empty')
           echo "released_at=$RELEASED_AT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1320,8 +1320,8 @@ jobs:
         run: |
           RELEASE_JSON=$(gh api "repos/${{ github.repository }}/releases/tags/${{ inputs.tag }}" 2>/dev/null || echo '{}')
           echo "$RELEASE_JSON" | jq -r '.body // empty' > /tmp/changelog.md || true
-          CREATED_AT=$(echo "$RELEASE_JSON" | jq -r '.created_at // empty')
-          echo "released_at=$CREATED_AT" >> "$GITHUB_OUTPUT"
+          RELEASED_AT=$(echo "$RELEASE_JSON" | jq -r '.published_at // .created_at // empty')
+          echo "released_at=$RELEASED_AT" >> "$GITHUB_OUTPUT"
 
       - name: Write merged manifest from dist recording job
         working-directory: _workflows

--- a/cmd/record-release/main.go
+++ b/cmd/record-release/main.go
@@ -99,7 +99,7 @@ func main() {
 	flag.StringVar(&configSchemaPath, "config-schema", "", "Path to config_schema.json file (optional)")
 	flag.StringVar(&capabilitiesPath, "capabilities", "", "Path to baton_capabilities.json file (optional)")
 	var releasedAt string
-	flag.StringVar(&releasedAt, "released-at", "", "Release creation timestamp in RFC 3339 format (optional, defaults to server time)")
+	flag.StringVar(&releasedAt, "released-at", "", "Release publish timestamp in RFC 3339 format (optional, defaults to server time)")
 	flag.StringVar(&token, "token", "", "Bearer token (or set REGISTRY_API_TOKEN env var)")
 	flag.Parse()
 


### PR DESCRIPTION
## Summary

- Fix draft release timestamps showing the wrong date in the connector registry
- The workflow was using GitHub's `created_at` (when the draft was first created) instead of `published_at` (when it was actually published) for the registry's `released_at` field
- For draft releases these can be hours or days apart, causing the registry to show a stale publish date

Fixes: https://linear.app/ductone/issue/CE-625/release-time-and-date-is-wrong-on-connector-releases

## Test plan

- [ ] Create a draft release, wait, then publish it -- verify the registry shows the publish time, not the draft creation time
- [ ] Verify non-draft releases still record the correct timestamp (`published_at` equals `created_at` for direct publishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)