### PR TITLE
Pin golangci-lint in verify workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run linters
       uses: golangci/golangci-lint-action@v9
       with:
-       version: latest
+       version: v2.11.4
        args: --timeout=6m
        working-directory: _caller
   test:


### PR DESCRIPTION
Why

The shared verify workflow currently asks golangci-lint-action for latest. Recent connector PRs show latest moved from v2.11.4 to v2.12.x and started surfacing new goconst findings across repos. Pinning the tool version makes shared lint behavior deterministic while the v2.12.x bump can be tested separately.

What this changes

Pins the verify lint job to golangci-lint v2.11.4, the last version observed passing before the goconst behavior change.