### PR TITLE
Preserve Lambda ECR refs in release manifests

### DIFF
--- a/cmd/extract-images/main.go
+++ b/cmd/extract-images/main.go
@@ -148,8 +148,11 @@ func extractLambdaImage(content []byte, repoName, version string, images map[str
 			continue
 		}
 
-		ref := fmt.Sprintf("%s:%s", repoName, tag)
-		uri := fmt.Sprintf("%s@%s", repoName, line.digest)
+		ref := line.ref
+		uri, ok := digestPinnedURI(ref, line.digest)
+		if !ok {
+			continue
+		}
 		isIndex := false
 		images[lambdaArm64ImageKey] = pb.Image_builder{
 			Ref:     &ref,

--- a/cmd/extract-images/main_test.go
+++ b/cmd/extract-images/main_test.go
@@ -21,7 +21,7 @@ ccc333  public.ecr.aws/conductorone/baton-example:0.1.2
 	}
 }
 
-func TestExtractLambdaImageUsesGenericRef(t *testing.T) {
+func TestExtractLambdaImagePreservesECRRef(t *testing.T) {
 	images := make(map[string]*pb.Image)
 	found := extractLambdaImage([]byte(`
 ddd444  168442440833.dkr.ecr.us-west-2.amazonaws.com/baton-example:0.1.2-arm64
@@ -34,8 +34,11 @@ ddd444  168442440833.dkr.ecr.us-west-2.amazonaws.com/baton-example:0.1.2-arm64
 	if image == nil {
 		t.Fatalf("missing %s image", lambdaArm64ImageKey)
 	}
-	if image.GetRef() != "baton-example:0.1.2-arm64" {
+	if image.GetRef() != "168442440833.dkr.ecr.us-west-2.amazonaws.com/baton-example:0.1.2-arm64" {
 		t.Fatalf("lambda ref = %q", image.GetRef())
+	}
+	if image.GetUri() != "168442440833.dkr.ecr.us-west-2.amazonaws.com/baton-example@sha256:ddd444" {
+		t.Fatalf("lambda uri = %q", image.GetUri())
 	}
 	if image.GetDigest() != "sha256:ddd444" {
 		t.Fatalf("lambda digest = %q", image.GetDigest())


### PR DESCRIPTION
**Why**

The release workflow now records `lambda-arm64` image metadata for registry API ingest, but it rewrites the Lambda image ref to a short repo tag. C1 expects release metadata to carry a full or templated ECR image URI so it can resolve the account and region before Lambda deployment.

**What this changes**

- Preserves the full Lambda ECR image ref from GoReleaser's digest output.
- Builds the digest-pinned Lambda image URI from that same full ref.
- Updates the extractor test to assert the deployable ECR ref is retained.

**Validation**

- `go test ./cmd/extract-images ./cmd/record-release`
- `go test ./...`
- `git diff --check`
