### PR TITLE
Verify release checkouts use tag commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,8 +177,24 @@ jobs:
         with:
           path: _caller
           repository: ${{ github.event.repository.full_name }}
+          ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify caller checkout matches release tag
+        working-directory: _caller
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "::error::Checked out $head_commit but refs/tags/$RELEASE_TAG resolves to $tag_commit"
+            exit 1
+          fi
+          echo "Verified $RELEASE_TAG at $head_commit"
 
       - name: Checkout connector workflows
         uses: actions/checkout@v5
@@ -429,8 +445,24 @@ jobs:
         with:
           path: _caller
           repository: ${{ github.event.repository.full_name }}
+          ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify caller checkout matches release tag
+        working-directory: _caller
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "::error::Checked out $head_commit but refs/tags/$RELEASE_TAG resolves to $tag_commit"
+            exit 1
+          fi
+          echo "Verified $RELEASE_TAG at $head_commit"
 
       - name: Checkout connector workflows
         uses: actions/checkout@v5
@@ -721,8 +753,24 @@ jobs:
         with:
           path: _caller
           repository: ${{ github.event.repository.full_name }}
+          ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify caller checkout matches release tag
+        working-directory: _caller
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "::error::Checked out $head_commit but refs/tags/$RELEASE_TAG resolves to $tag_commit"
+            exit 1
+          fi
+          echo "Verified $RELEASE_TAG at $head_commit"
 
       - name: Checkout connector workflows
         if: inputs.docker == true || inputs.lambda == true
@@ -1207,7 +1255,27 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: _connector
+          repository: ${{ github.event.repository.full_name }}
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify connector checkout matches release tag
+        id: verify-connector-checkout
+        working-directory: _connector
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "::error::Checked out $head_commit but refs/tags/$RELEASE_TAG resolves to $tag_commit"
+            exit 1
+          fi
+          echo "commit_sha=$head_commit" >> "$GITHUB_OUTPUT"
+          echo "Verified $RELEASE_TAG at $head_commit"
 
       - name: Read connector documentation
         id: read-docs
@@ -1288,7 +1356,7 @@ jobs:
             -name "${{ github.event.repository.name }}" \
             -version "${{ inputs.tag }}" \
             -repository-url "https://github.com/${{ github.repository }}" \
-            -commit-sha "${{ github.sha }}" \
+            -commit-sha "${{ steps.verify-connector-checkout.outputs.commit_sha }}" \
             -workflow-run-id "${{ github.run_id }}" \
             -registry-url "https://dist.conductorone.com" \
             $DOCS_FLAG \

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -100,6 +100,13 @@ Post-release validation (non-blocking):
 
 ## Security Properties
 
+### Release Source Identity
+
+Release jobs check out caller code from `refs/tags/<tag>` and verify the
+checked-out commit matches the tag target before building artifacts or recording
+registry metadata. This prevents a release run from publishing artifacts for one
+commit while labeling them as a different tag.
+
 ### Keyless Signing
 
 All signatures use Sigstore's keyless signing:


### PR DESCRIPTION
**Why**

The release workflow accepts a tag input and then builds, signs, uploads, and records release metadata. The caller checkout should be tied directly to that tag so a release run cannot publish artifacts from one commit while labeling or recording them as another tag.

**What this changes**

- Checks out caller code from `refs/tags/${{ inputs.tag }}` in the binaries, Windows, Docker, and registry metadata jobs.
- Verifies each checked-out caller repository HEAD matches the tag target before continuing.
- Records the verified connector checkout commit SHA in the registry metadata instead of using `github.sha`.
- Documents the release source identity invariant in the release workflow docs.

This PR is stacked on #74 and should merge after it.

**Validation**

- Parsed `.github/workflows/release.yaml` with `yq`.
- Ran `git diff --check`.
- Verified all caller/connector release checkouts use `refs/tags/${{ inputs.tag }}`.
- Ran `orch-cross-review` focused on annotated/lightweight tags, cross-runner behavior, registry commit recording, and regressions; no blockers were reported.
- Ran a private connector release canary against this branch; the release completed successfully, including macOS, Windows, Docker, manifest publication, artifact verification, and registry recording jobs.