### PR TITLE
Add review summary and run link to PR reviews

### DIFF
--- a/.github/actions/pr-review/prompts/base-pr-review.md
+++ b/.github/actions/pr-review/prompts/base-pr-review.md
@@ -11,6 +11,7 @@ Read `.github/pr-context.json` — it contains pre-fetched PR data with these fi
 - `current_sha`: the HEAD SHA (use this as `CURRENT_SHA`)
 - `current_base_sha`: the PR base SHA (use this as `CURRENT_BASE_SHA`)
 - `workflow_ref`: the workflow ref that owns this review state (use this as `CURRENT_WORKFLOW_REF`)
+- `review_run_url`: link to this review workflow run
 - `summary_heading`: the exact markdown heading for the summary comment
 - `review_mode`: `"incremental"` or `"full"`
 - `last_reviewed_sha`: the SHA from the previous review, used only for deduplication
@@ -89,7 +90,8 @@ Do not delete existing summary comments before the new review has been posted.
 Use this template for the summary body. The heading must be exactly the `summary_heading`
 value from `.github/pr-context.json`.
 
-Always include a short review summary before the issue sections. Use 1-3 sentences.
+Always include the review run link and a short review summary before the issue sections.
+Use 1-3 sentences for the review summary.
 For incremental reviews, explicitly say what the new commits changed and whether prior
 bot feedback appears addressed. Use `existing_findings`, `comments`, and
 `.github/resolved-threads.json` as context, but verify against the current diff before
@@ -97,16 +99,27 @@ claiming something was fixed. If there were no prior findings and no new finding
 what changed and that no new issues were found. Do not leave the summary as only counts
 plus "None found" sections.
 
+For incremental reviews where prior bot feedback was addressed, also include an
+`Addressed Feedback` section after `Review Summary`. Use concise bullets that identify
+the previous concern and how the new commits addressed it. Omit `Addressed Feedback`
+when there is no prior bot feedback or nothing appears addressed.
+
 ```
 <summary_heading> <PR title>
 
 **Blocking Issues: N** | **Suggestions: M** | **Threads Resolved: R**
 _Review mode: incremental since `<last_reviewed_sha short>`_ (or _Review mode: full_)
+[View review run](<review_run_url>)
 
 ### Review Summary
 <1-3 sentences describing what was reviewed. In incremental mode, include addressed
 prior feedback when applicable, for example "The previous pagination suggestion is now
 addressed by passing the page token through the client call. No new issues found.">
+
+### Addressed Feedback
+<incremental reviews only, and only when applicable: one bullet per previous bot finding
+that the new commits appear to address. Omit this section when no prior feedback was
+addressed.>
 
 ### Security Issues
 <one-liner per finding with file:line, or "None found.">
@@ -120,8 +133,9 @@ addressed by passing the page token through the client call. No new issues found
 <!-- review-state: {"last_reviewed_sha": "CURRENT_SHA", "base_sha": "CURRENT_BASE_SHA", "workflow_ref": "CURRENT_WORKFLOW_REF"} -->
 ```
 
-Replace `CURRENT_SHA`, `CURRENT_BASE_SHA`, and `CURRENT_WORKFLOW_REF` with the values
-from `.github/pr-context.json`.
+Replace `CURRENT_SHA`, `CURRENT_BASE_SHA`, `CURRENT_WORKFLOW_REF`, and
+`<review_run_url>` with the values from `.github/pr-context.json`. If `review_run_url`
+is empty, omit the review run link line.
 
 After the summary table, include a collapsible section with a single fenced code block
 that lists every finding as a concise, actionable description a developer can follow

--- a/.github/actions/pr-review/prompts/base-pr-review.md
+++ b/.github/actions/pr-review/prompts/base-pr-review.md
@@ -92,17 +92,12 @@ value from `.github/pr-context.json`.
 
 Always include the review run link and a short review summary before the issue sections.
 Use 1-3 sentences for the review summary.
-For incremental reviews, explicitly say what the new commits changed and whether prior
-bot feedback appears addressed. Use `existing_findings`, `comments`, and
-`.github/resolved-threads.json` as context, but verify against the current diff before
-claiming something was fixed. If there were no prior findings and no new findings, say
-what changed and that no new issues were found. Do not leave the summary as only counts
-plus "None found" sections.
-
-For incremental reviews where prior bot feedback was addressed, also include an
-`Addressed Feedback` section after `Review Summary`. Use concise bullets that identify
-the previous concern and how the new commits addressed it. Omit `Addressed Feedback`
-when there is no prior bot feedback or nothing appears addressed.
+For incremental reviews, explicitly say what the new commits changed. If prior bot
+feedback appears addressed, say that in the review summary. Use `existing_findings`,
+`comments`, and `.github/resolved-threads.json` as context, but verify against the
+current diff before claiming something was fixed. If there were no prior findings and
+no new findings, say what changed and that no new issues were found. Do not leave the
+summary as only counts plus "None found" sections.
 
 ```
 <summary_heading> <PR title>
@@ -115,11 +110,6 @@ _Review mode: incremental since `<last_reviewed_sha short>`_ (or _Review mode: f
 <1-3 sentences describing what was reviewed. In incremental mode, include addressed
 prior feedback when applicable, for example "The previous pagination suggestion is now
 addressed by passing the page token through the client call. No new issues found.">
-
-### Addressed Feedback
-<incremental reviews only, and only when applicable: one bullet per previous bot finding
-that the new commits appear to address. Omit this section when no prior feedback was
-addressed.>
 
 ### Security Issues
 <one-liner per finding with file:line, or "None found.">

--- a/.github/actions/pr-review/prompts/base-pr-review.md
+++ b/.github/actions/pr-review/prompts/base-pr-review.md
@@ -89,11 +89,24 @@ Do not delete existing summary comments before the new review has been posted.
 Use this template for the summary body. The heading must be exactly the `summary_heading`
 value from `.github/pr-context.json`.
 
+Always include a short review summary before the issue sections. Use 1-3 sentences.
+For incremental reviews, explicitly say what the new commits changed and whether prior
+bot feedback appears addressed. Use `existing_findings`, `comments`, and
+`.github/resolved-threads.json` as context, but verify against the current diff before
+claiming something was fixed. If there were no prior findings and no new findings, say
+what changed and that no new issues were found. Do not leave the summary as only counts
+plus "None found" sections.
+
 ```
 <summary_heading> <PR title>
 
 **Blocking Issues: N** | **Suggestions: M** | **Threads Resolved: R**
 _Review mode: incremental since `<last_reviewed_sha short>`_ (or _Review mode: full_)
+
+### Review Summary
+<1-3 sentences describing what was reviewed. In incremental mode, include addressed
+prior feedback when applicable, for example "The previous pagination suggestion is now
+addressed by passing the page token through the client call. No new issues found.">
 
 ### Security Issues
 <one-liner per finding with file:line, or "None found.">

--- a/.github/actions/pr-review/scripts/fetch-pr-context.py
+++ b/.github/actions/pr-review/scripts/fetch-pr-context.py
@@ -118,6 +118,9 @@ def main():
     repo = os.environ.get("GITHUB_REPOSITORY", "")
     pr_number = os.environ.get("PR_NUMBER", "")
     workflow_ref = os.environ.get("GITHUB_WORKFLOW_REF", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    review_run_url = f"{server_url}/{repo}/actions/runs/{run_id}" if repo and run_id else None
     summary_heading = os.environ.get(
         "REVIEW_SUMMARY_HEADING",
         DEFAULT_REVIEW_SUMMARY_HEADING,
@@ -236,6 +239,7 @@ def main():
         "current_sha": current_sha,
         "current_base_sha": current_base_sha,
         "workflow_ref": workflow_ref,
+        "review_run_url": review_run_url,
         "summary_heading": summary_heading,
         "review_mode": review_mode,
         "last_reviewed_sha": last_reviewed_sha,

--- a/.github/workflows/general-pr-review.yaml
+++ b/.github/workflows/general-pr-review.yaml
@@ -26,4 +26,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ github.event.pull_request.number }}
           review_prompt: general
-    timeout-minutes: 10
+    timeout-minutes: 15

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -32,4 +32,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ github.event.pull_request.number }}
           review_prompt: ${{ inputs.review_prompt || 'connector' }}
-    timeout-minutes: 10
+    timeout-minutes: 15


### PR DESCRIPTION
**Why**

The structured PR review summary can still be hard to scan when a follow-up review has no findings. Reviewers need the summary comment to say what changed, whether prior bot feedback was addressed, and where to inspect the run without restoring the older trusted-code behavior.

**What this changes**

Adds `review_run_url` to the pre-fetched PR context and requires the shared prompt to include a run link plus a short `Review Summary` before the finding sections. Incremental reviews are instructed to mention addressed prior bot feedback in that summary while continuing to use the safe base-checkout and GitHub API diff model.

**Validation**

- `git diff --check`
- `fetch-pr-context.py` compiles with an isolated pycache
- Canary PR flagged a new unsafe type assertion, linked the review run, then updated the same summary after the fix with zero blocking issues and the prior feedback marked addressed

<img width="898" height="660" alt="Screenshot 2026-05-14 at 14 14 38" src="https://github.com/user-attachments/assets/dd17bbc9-0e85-4570-887c-e49b77025b9d" />
