### PR TITLE
Fix MDX lint URL false positives in prose

### DIFF
--- a/tools/mdx-lint/mdx-lint.mjs
+++ b/tools/mdx-lint/mdx-lint.mjs
@@ -152,11 +152,6 @@ function validateTree(tree) {
       case "definition":
         validateUrlNode(node);
         break;
-      case "text":
-        if (containsDangerousUrl(node.value)) {
-          fail(node, "contains a dangerous URL scheme");
-        }
-        break;
     }
   });
 }

--- a/tools/mdx-lint/mdx-lint.test.mjs
+++ b/tools/mdx-lint/mdx-lint.test.mjs
@@ -44,6 +44,19 @@ Read the public setup guide at https://example.com/docs.
 `);
   });
 
+  it("allows dangerous URL scheme names in plain prose", async () => {
+    await expectValid(`<Steps>
+  <Step>
+    In the permissions section, choose the relevant permissions:
+
+    To sync (read) data:
+
+    - Project: Read
+  </Step>
+</Steps>
+`);
+  });
+
   it("rejects unknown JSX components", async () => {
     await expectInvalid("<Unknown />\n", /disallowed JSX component "Unknown"/);
   });


### PR DESCRIPTION
**Why**

Connector docs can contain ordinary prose such as “To sync (read) data:”. The MDX validator was scanning all text nodes for dangerous URL schemes, so that prose failed as if it were an actual data URL. Connector repos should not need wording-only PRs to work around that false positive.

**What this changes**

Narrows dangerous URL checks to URL-bearing markdown nodes and JSX attributes. Plain text is no longer scanned as a URL, while links, images, definitions, href/src/action attributes, and encoded dangerous URL schemes remain blocked.

Adds a regression test for the Sentry-style Step content that triggered the failure.

**Validation**

- npm test --prefix tools/mdx-lint
- patched validator accepts the current baton-sentry docs/connector.mdx
- patched validator still rejects an explicit data: markdown link
- git diff --check

**Rollout**

After merge, publish the updated reusable workflow ref used by connector repos. They currently call ConductorOne/github-workflows at v4, so v4 must point at this fix before baton-sentry main stops using the old validator.