### PR TITLE
sync-test: skip when required connector secret is empty

### DIFF
--- a/actions/sync-test/action.yaml
+++ b/actions/sync-test/action.yaml
@@ -18,6 +18,17 @@ inputs:
   sleep:
     description: 'Sleep time in seconds to wait after each write operation. If not provided, no sleep will be performed.'
     required: false
+  required-secrets:
+    description: |
+      Comma- or newline-separated list of env var names that must be non-empty for
+      this test to run. If any are empty (e.g. the workflow could not pull a fork
+      secret, or the org secret has not been provisioned yet), the action logs a
+      skip notice and exits 0 instead of failing on a missing-credential side
+      effect (no grants returned, empty token, etc.).
+
+      Example:
+        required-secrets: BATON_NETLIFY_ACCESS_TOKEN
+    required: false
 
 runs:
   using: "composite"
@@ -33,5 +44,6 @@ runs:
         BATON_PRINCIPAL_TYPE: ${{ inputs.baton-principal-type }}
         BATON: baton
         SLEEP: ${{ inputs.sleep }}
+        REQUIRED_SECRETS: ${{ inputs.required-secrets }}
       run: ${{ github.action_path }}/grant-revoke.sh
       shell: bash

--- a/actions/sync-test/grant-revoke.sh
+++ b/actions/sync-test/grant-revoke.sh
@@ -16,6 +16,20 @@ if ! command -v $BATON &> /dev/null; then
   exit 1
 fi
 
+# If required-secrets input was provided, skip the test when any listed env
+# var is empty. This unblocks PRs from forks or repos whose org secret has
+# not been provisioned yet — running the binary without credentials yields
+# empty grants, which then fails the jq exit-status assertion below.
+if [ -n "${REQUIRED_SECRETS:-}" ]; then
+  # Normalize: split on comma or whitespace; iterate non-empty tokens.
+  for name in ${REQUIRED_SECRETS//,/ }; do
+    if [ -z "${!name:-}" ]; then
+      echo "::notice title=sync-test skipped::required secret $name is empty; skipping connector sync test"
+      exit 0
+    fi
+  done
+fi
+
 # Error on unbound variables now that we've set BATON
 set -u
 


### PR DESCRIPTION
## Why

About two dozen connector testability PRs across the baton-* repos are stuck on the shared `sync-test` action. The action calls the connector binary, then uses `baton grants` + a `jq --exit-status` filter to assert a specific test grant exists.

When the connector's credentials env var isn't populated — because the org secret hasn't been provisioned for that repo yet, or the workflow ran from a fork — the binary runs but returns no grants, the jq filter exits non-zero, and the job fails. The PR author can't fix that from the code side, so the testability PRs sit indefinitely.

## What this does

Adds an optional `required-secrets` input to `actions/sync-test`. It takes a comma- or whitespace-separated list of env var names. If any are empty when `grant-revoke.sh` starts, the action logs an `::notice::` and exits 0 instead of running the test.

```yaml
- uses: ConductorOne/github-workflows/actions/sync-test@v3
  with:
    connector: ./baton-foo
    baton-entitlement: "role:owner:assigned"
    baton-principal: "user@example.com"
    required-secrets: BATON_FOO_TOKEN
```

Existing callers with no `required-secrets` input behave exactly as before.

## Test plan

- [x] Verified the bash-parameter-expansion logic handles both comma and whitespace separators, and exits 0 on the first empty var.
- [ ] Once merged + tagged, opt one stuck baton-* repo into `required-secrets` and confirm the test job skips cleanly with the credentials secret unset, and still runs when set.

## Follow-ups (out of scope for this PR)

- Tag a new major (v3) once enough consumers are migrated, or backport to v2 if that's preferred.
- The longer-term answer is to point the test at a mock server using the new `--base-url` flag from the connector testability project — this PR just unblocks the queue in the meantime.