### PR TITLE
Derive shortened release role names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,6 +204,19 @@ jobs:
           ref: ${{ needs.determine-workflows-ref.outputs.ref }}
           persist-credentials: false
 
+      - name: Derive AWS role names
+        id: role-names
+        working-directory: _workflows
+        shell: bash
+        env:
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          bash ./scripts/derive-iam-role-name.sh \
+            --prefix GHA-Artifacts- \
+            --suffix "${REPO_OWNER}-${REPO_NAME}" \
+            --output-name gha_artifacts_role_name >> "$GITHUB_OUTPUT"
+
       - name: Set up Go for caller
         uses: actions/setup-go@v6
         with:
@@ -256,7 +269,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::025044153841:role/GHA-Artifacts-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}
+          role-to-assume: arn:aws:iam::025044153841:role/${{ steps.role-names.outputs.gha_artifacts_role_name }}
           aws-region: us-west-2
 
       - name: Run GoReleaser
@@ -472,6 +485,19 @@ jobs:
           ref: ${{ needs.determine-workflows-ref.outputs.ref }}
           persist-credentials: false
 
+      - name: Derive AWS role names
+        id: role-names
+        working-directory: _workflows
+        shell: bash
+        env:
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          bash ./scripts/derive-iam-role-name.sh \
+            --prefix GHA-Artifacts- \
+            --suffix "${REPO_OWNER}-${REPO_NAME}" \
+            --output-name gha_artifacts_role_name >> "$GITHUB_OUTPUT"
+
       - name: Set up Go for caller
         uses: actions/setup-go@v6
         with:
@@ -639,7 +665,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::025044153841:role/GHA-Artifacts-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}
+          role-to-assume: arn:aws:iam::025044153841:role/${{ steps.role-names.outputs.gha_artifacts_role_name }}
           aws-region: us-west-2
 
       - name: Calculate S3 directory
@@ -781,6 +807,24 @@ jobs:
           ref: ${{ needs.determine-workflows-ref.outputs.ref }}
           persist-credentials: false
 
+      - name: Derive AWS role names
+        id: role-names
+        if: inputs.docker == true || inputs.lambda == true
+        working-directory: _workflows
+        shell: bash
+        env:
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          bash ./scripts/derive-iam-role-name.sh \
+            --prefix GHA-Artifacts- \
+            --suffix "${REPO_OWNER}-${REPO_NAME}" \
+            --output-name gha_artifacts_role_name >> "$GITHUB_OUTPUT"
+          bash ./scripts/derive-iam-role-name.sh \
+            --prefix GitHubActionsECRPushRole- \
+            --suffix "${REPO_NAME}" \
+            --output-name ecr_push_role_name >> "$GITHUB_OUTPUT"
+
       - name: Set up Go for caller
         if: inputs.docker == true || inputs.lambda == true
         uses: actions/setup-go@v6
@@ -875,7 +919,7 @@ jobs:
         if: inputs.docker == true
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::025044153841:role/GHA-Artifacts-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}
+          role-to-assume: arn:aws:iam::025044153841:role/${{ steps.role-names.outputs.gha_artifacts_role_name }}
           aws-region: us-east-1
 
       - name: Login to Public ECR
@@ -899,7 +943,7 @@ jobs:
         if: inputs.lambda == true
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: "arn:aws:iam::168442440833:role/GitHubActionsECRPushRole-${{ github.event.repository.name }}"
+          role-to-assume: "arn:aws:iam::168442440833:role/${{ steps.role-names.outputs.ecr_push_role_name }}"
           aws-region: us-west-2
 
       - name: Login to Lambda ECR
@@ -1015,6 +1059,19 @@ jobs:
           ref: ${{ needs.determine-workflows-ref.outputs.ref }}
           persist-credentials: false
 
+      - name: Derive AWS role names
+        id: role-names
+        working-directory: _workflows
+        shell: bash
+        env:
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          bash ./scripts/derive-iam-role-name.sh \
+            --prefix GHA-Artifacts- \
+            --suffix "${REPO_OWNER}-${REPO_NAME}" \
+            --output-name gha_artifacts_role_name >> "$GITHUB_OUTPUT"
+
       - name: Set up Go for workflows
         uses: actions/setup-go@v6
         with:
@@ -1042,7 +1099,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::025044153841:role/GHA-Artifacts-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}
+          role-to-assume: arn:aws:iam::025044153841:role/${{ steps.role-names.outputs.gha_artifacts_role_name }}
           aws-region: us-west-2
 
       - name: Create unified checksums file

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,15 @@ protofmt:
 	@echo "Protobuf formatting complete."
 
 .PHONY: test
-test:
+test: test-go test-scripts
+
+.PHONY: test-go
+test-go:
 	go test ./cmd/record-release ./cmd/generate-manifest ./cmd/merge-manifests
+
+.PHONY: test-scripts
+test-scripts:
+	bash scripts/test-derive-iam-role-name.sh
 
 .PHONY: workflow-validate
 workflow-validate:

--- a/scripts/derive-iam-role-name.sh
+++ b/scripts/derive-iam-role-name.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 
 iam_role_name_max_length=64
 iam_role_name_hash_length=8

--- a/scripts/derive-iam-role-name.sh
+++ b/scripts/derive-iam-role-name.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+iam_role_name_max_length=64
+iam_role_name_hash_length=8
+
+usage() {
+  echo "usage: derive-iam-role-name.sh --prefix PREFIX --suffix SUFFIX --output-name NAME" >&2
+}
+
+prefix=""
+suffix=""
+output_name="iam_role_name"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      prefix="${2:-}"
+      shift 2
+      ;;
+    --suffix)
+      suffix="${2:-}"
+      shift 2
+      ;;
+    --output-name)
+      output_name="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$prefix" ] || [ -z "$suffix" ] || [ -z "$output_name" ]; then
+  usage
+  echo "prefix, suffix, and output-name are required" >&2
+  exit 2
+fi
+
+if [[ ! "$output_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "output-name must be a safe GitHub output key" >&2
+  exit 2
+fi
+
+role_name="${prefix}${suffix}"
+if [ "${#role_name}" -gt "$iam_role_name_max_length" ]; then
+  if command -v shasum >/dev/null 2>&1; then
+    hash_output="$(printf '%s' "$role_name" | shasum -a 256)"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    hash_output="$(printf '%s' "$role_name" | sha256sum)"
+  else
+    echo "shasum or sha256sum is required" >&2
+    exit 1
+  fi
+  hash="${hash_output%% *}"
+  hash="${hash:0:$iam_role_name_hash_length}"
+  keep=$((iam_role_name_max_length - iam_role_name_hash_length - 1))
+  role_name="${role_name:0:$keep}-${hash}"
+fi
+
+printf '%s=%s\n' "$output_name" "$role_name"

--- a/scripts/test-derive-iam-role-name.sh
+++ b/scripts/test-derive-iam-role-name.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="${script_dir}/derive-iam-role-name.sh"
+
+assert_output() {
+  local want="$1"
+  shift
+  local got
+  got="$(bash "$script" "$@")"
+  if [ "$got" != "$want" ]; then
+    echo "got:  $got" >&2
+    echo "want: $want" >&2
+    exit 1
+  fi
+}
+
+assert_output \
+  "gha_artifacts_role_name=GHA-Artifacts-ConductorOne-baton-axiomatic-jira" \
+  --prefix GHA-Artifacts- \
+  --suffix ConductorOne-baton-axiomatic-jira \
+  --output-name gha_artifacts_role_name
+
+assert_output \
+  "gha_artifacts_role_name=GHA-Artifacts-ConductorOne-baton-axiomatic-github-enter-f6552060" \
+  --prefix GHA-Artifacts- \
+  --suffix ConductorOne-baton-axiomatic-github-enterprise-cloud \
+  --output-name gha_artifacts_role_name
+
+assert_output \
+  "ecr_push_role_name=GitHubActionsECRPushRole-baton-axiomatic-github-enterprise-cloud" \
+  --prefix GitHubActionsECRPushRole- \
+  --suffix baton-axiomatic-github-enterprise-cloud \
+  --output-name ecr_push_role_name

--- a/scripts/test-derive-iam-role-name.sh
+++ b/scripts/test-derive-iam-role-name.sh
@@ -29,7 +29,19 @@ assert_output \
   --output-name gha_artifacts_role_name
 
 assert_output \
+  "gha_artifacts_role_name=GHA-Artifacts-ConductorOne-baton-axiomatic-github-enter-571914a9" \
+  --prefix GHA-Artifacts- \
+  --suffix ConductorOne-baton-axiomatic-github-enterprise-cloud-extra-long-name \
+  --output-name gha_artifacts_role_name
+
+assert_output \
   "ecr_push_role_name=GitHubActionsECRPushRole-baton-axiomatic-github-enterprise-cloud" \
   --prefix GitHubActionsECRPushRole- \
   --suffix baton-axiomatic-github-enterprise-cloud \
+  --output-name ecr_push_role_name
+
+assert_output \
+  "ecr_push_role_name=GitHubActionsECRPushRole-baton-axiomatic-github-enterpr-302f51c5" \
+  --prefix GitHubActionsECRPushRole- \
+  --suffix baton-axiomatic-github-enterprise-cloud-extra \
   --output-name ecr_push_role_name


### PR DESCRIPTION
## Why

The reusable connector release workflow assumes artifact and ECR push roles whose names are derived from repository names. Long connector repository names can exceed the AWS IAM 64-character role-name limit, so the workflow needs to derive the same shortened names that ops creates.

## What this changes

Adds a checked-in helper script for deterministic IAM role-name derivation and uses it before AWS role assumption in the standard release jobs. Existing short names are unchanged; over-limit names keep the first 55 characters plus an 8-character SHA-256 prefix.

Cross-review follow-up added expanded golden vectors and sets `LC_ALL=C` so bash length and slicing semantics match the Go implementations byte-for-byte.

## Validation

- `make test`
- `yq "." .github/workflows/release.yaml >/dev/null`
- `git diff --check`

## Merge order

Merge with `ductone/ops#7767` and `ConductorOne/github-axiomatic-workflows#1` before relying on shortened names for long connector repositories.