### PR TITLE
bump internal action refs from v2 to v4

### DIFF
--- a/actions/account-provisioning/action.yaml
+++ b/actions/account-provisioning/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Baton
-      uses: ConductorOne/github-workflows/actions/get-baton@v2
+      uses: ConductorOne/github-workflows/actions/get-baton@v4
 
     - name: Account Provisioning Test
       env:

--- a/actions/account-status-lifecycle-test/action.yaml
+++ b/actions/account-status-lifecycle-test/action.yaml
@@ -32,7 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Baton
-      uses: ConductorOne/github-workflows/actions/get-baton@v2
+      uses: ConductorOne/github-workflows/actions/get-baton@v4
 
     - name: Account Status Lifecycle Test
       env:

--- a/actions/sync-test/action.yaml
+++ b/actions/sync-test/action.yaml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Baton
-      uses: ConductorOne/github-workflows/actions/get-baton@v2
+      uses: ConductorOne/github-workflows/actions/get-baton@v4
 
     - name: Grant Revoke
       env:


### PR DESCRIPTION
sync-test, account-provisioning, and account-status-lifecycle-test pinned get-baton@v2 internally. The v2 tag still installs baton from the archived conductorone/baton repo, and GitHub resolves nested action refsindependently, so these actions bypassed the baton-sdk fix from https://github.com/ConductorOne/github-workflows/pull/89