### PR TITLE
Enable long paths for Windows releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -453,6 +453,10 @@ jobs:
     outputs:
       windows_manifest: ${{ steps.generate-windows-manifest.outputs.windows_manifest }}
     steps:
+      - name: Enable Git long paths
+        shell: pwsh
+        run: git config --system core.longpaths true
+
       - name: Checkout caller repo
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Why
The Windows MSI release job checks out caller repositories before building artifacts. Repositories with deep vendored paths can fail checkout under Windows default path limits before GoReleaser runs.

## What this changes
Adds a first step in the Windows release job that sets system Git `core.longpaths=true` before checkout. This gives standard release jobs the same long-path handling as the axiomatic release workflow.