### PR TITLE
Bump pr-review model to Claude Opus 4.8

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -83,7 +83,7 @@ runs:
       github_token: ${{ inputs.github_token }}
       include_fix_links: true
       allowed_bots: "*"
-      claude_args: --model claude-opus-4-6 --max-turns 100 --allowedTools "Read,Glob,Grep,Skill,Task,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+      claude_args: --model claude-opus-4-8 --max-turns 100 --allowedTools "Read,Glob,Grep,Skill,Task,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
       prompt: ${{ env.REVIEW_PROMPT }}
   - name: Upload review context artifacts
     if: always()


### PR DESCRIPTION
## Why

The pr-review action pins the reviewer model to Claude Opus 4.6. Opus 4.8 is the current Opus-tier model (stronger bug-finding, clearer explanations, better long-horizon agentic behavior), so the required PR-review gate should run on it.

## What this changes

- `.github/actions/pr-review/action.yml`: `--model claude-opus-4-6` → `claude-opus-4-8` (one line). No other behavior changes.

## Compatibility note

`claude-code-action` forwards `--model` opaquely to the bundled Claude Code CLI, which forwards the string to the API (no client-side model allowlist). The action's `claude_args` pass no thinking/sampling/prefill arguments, so none of the Opus 4.7+ request-surface breaking changes apply here — the bump is a model-string change only.

One thing for the reviewer to weigh: this branch keeps the existing pinned `claude-code-action@661a6fefbd05` (v1.0.130, 2026-05-21). That release predates `claude-opus-4-8` appearing in the public model catalog, so the bundled CLI may not "know" the model for any client-side defaulting. If we want belt-and-suspenders, pair this with a bump of the pinned action SHA to a current release — but that is a supply-chain change that deserves its own diff review under the secret/write-token boundary, so it's intentionally left out of this PR.

Draft pending that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
