### PR TITLE
Reject embedded images in connector docs MDX lint

### DIFF
--- a/tools/mdx-lint/mdx-lint.mjs
+++ b/tools/mdx-lint/mdx-lint.mjs
@@ -175,8 +175,12 @@ function validateTree(tree) {
       case "html":
         fail(node, "contains raw HTML");
         break;
-      case "link":
+      // Embedded images make the registry's MDX renderer emit a <link rel=preload>, which its HTML validator rejects.
       case "image":
+      case "imageReference":
+        fail(node, "contains an embedded image; connector docs must not embed images");
+        break;
+      case "link":
       case "definition":
         validateUrlNode(node);
         break;

--- a/tools/mdx-lint/testdata/shared-mdx-validation.json
+++ b/tools/mdx-lint/testdata/shared-mdx-validation.json
@@ -96,5 +96,17 @@
     "valid": false,
     "errorContains": "dangerous URL scheme",
     "content": "[link](java&#x73;cript:alert(1))\n"
+  },
+  {
+    "name": "reject markdown embedded image",
+    "valid": false,
+    "errorContains": "must not embed images",
+    "content": "![diagram](./images/diagram.png)\n"
+  },
+  {
+    "name": "reject markdown image reference",
+    "valid": false,
+    "errorContains": "must not embed images",
+    "content": "![diagram][ref]\n\n[ref]: ./images/diagram.png\n"
   }
 ]


### PR DESCRIPTION
## Why

Connector docs (`docs/connector.mdx`) are compiled to HTML by the registry's React MDX renderer. An embedded image makes React emit a `<link rel="preload">` tag, and the registry's server-side HTML validator blocks `link` as a disallowed tag — so the docs-publish cron returns a 400 and wedges. It is also against team convention for connector docs to embed repo-local images. Rejecting embedded images at lint time catches this statically and fast, with no rendering.

## What this changes

- The shared MDX linter now rejects the markdown `image` (`![alt](url)`) and `imageReference` (`![alt][ref]`) mdast node types. The `image` node was previously only URL-checked alongside `link`/`definition`; it is now failed outright.
- JSX `<img>` was already rejected (not in the allowed component/element sets), so this closes the remaining markdown-syntax gap.
- Added test fixtures for both an embedded image and an image reference.

All 32 tests pass.