### PR TITLE
fix(account-status-lifecycle-test): read resource-level status for SDK compatibility

### DIFF
--- a/actions/account-status-lifecycle-test/README.md
+++ b/actions/account-status-lifecycle-test/README.md
@@ -118,9 +118,9 @@ The action performs account status tests based on the selected `test-flow`:
 
 The action checks for account status using the following logic:
 - Reads status from both places it can live, depending on the connector's baton-sdk version:
-  - Resource-level `resource.status.status` (`Status_ResourceStatus` enum, e.g. `RESOURCE_STATUS_ENABLED`) — used by newer SDKs.
-  - The deprecated UserTrait annotation's `status.status` (`UserTrait_Status_Status` enum, e.g. `STATUS_ENABLED`).
-- Prefers the resource-level value (normalized to the trait form) and falls back to the trait value. Newer SDKs default the deprecated trait status to `STATUS_ENABLED` when it isn't set explicitly, so the trait value alone is unreliable and is only used when no resource-level status is present.
+  - Resource-level `resource.status.status` (`Status_ResourceStatus` enum, e.g. `RESOURCE_STATUS_ENABLED`) — used by connectors built against baton-sdk **v0.19.0+**, which moved status from the trait to the resource ([ConductorOne/baton-sdk#996](https://github.com/ConductorOne/baton-sdk/pull/996)).
+  - The deprecated UserTrait annotation's `status.status` (`UserTrait_Status_Status` enum, e.g. `STATUS_ENABLED`) — used by connectors built against baton-sdk **< v0.19.0**.
+- Prefers the resource-level value (normalized to the trait form) and falls back to the trait value. On v0.19.0+ the deprecated trait status defaults to `STATUS_ENABLED` when it isn't set explicitly, so the trait value alone is unreliable and is only used when no resource-level status is present.
 - Checks if the resulting status equals `STATUS_ENABLED` (the only enabled status in baton-sdk)
 - Any other status value is considered disabled:
   - `STATUS_DISABLED` - Account is disabled

--- a/actions/account-status-lifecycle-test/README.md
+++ b/actions/account-status-lifecycle-test/README.md
@@ -117,8 +117,11 @@ The action performs account status tests based on the selected `test-flow`:
 ## Status Detection
 
 The action checks for account status using the following logic:
-- Extracts status from the UserTrait annotation
-- Checks if status equals `STATUS_ENABLED` (the only enabled status in baton-sdk)
+- Reads status from both places it can live, depending on the connector's baton-sdk version:
+  - Resource-level `resource.status.status` (`Status_ResourceStatus` enum, e.g. `RESOURCE_STATUS_ENABLED`) — used by newer SDKs.
+  - The deprecated UserTrait annotation's `status.status` (`UserTrait_Status_Status` enum, e.g. `STATUS_ENABLED`).
+- Prefers the resource-level value (normalized to the trait form) and falls back to the trait value. Newer SDKs default the deprecated trait status to `STATUS_ENABLED` when it isn't set explicitly, so the trait value alone is unreliable and is only used when no resource-level status is present.
+- Checks if the resulting status equals `STATUS_ENABLED` (the only enabled status in baton-sdk)
 - Any other status value is considered disabled:
   - `STATUS_DISABLED` - Account is disabled
   - `STATUS_DELETED` - Account is deleted

--- a/actions/account-status-lifecycle-test/account-status-lifecycle-test.sh
+++ b/actions/account-status-lifecycle-test/account-status-lifecycle-test.sh
@@ -41,20 +41,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_helpers/sleep.sh"
 
 # Function to get user status (enabled/disabled)
+#
+# Status can live in one of two places depending on the baton-sdk version the
+# connector was built with:
+#   * Resource-level: .resource.status.status, using the Status_ResourceStatus
+#     enum (e.g. "RESOURCE_STATUS_ENABLED"). This is where newer SDKs put it.
+#   * Deprecated trait-level: the UserTrait annotation's .status.status, using
+#     the UserTrait_Status_Status enum (e.g. "STATUS_ENABLED").
+#
+# We read both and prefer the resource-level value, normalizing it to the
+# trait-form ("RESOURCE_STATUS_ENABLED" -> "STATUS_ENABLED") so the rest of the
+# script keeps comparing against STATUS_ENABLED/STATUS_DISABLED. Newer SDKs
+# default the deprecated trait status to STATUS_ENABLED when it isn't set
+# explicitly, so the trait value alone is unreliable and is only used as a
+# fallback when no resource-level status is present.
 get_user_status() {
   local user_id="$1"
-  local status=$(baton resources -t "user" --output-format=json \
+  baton resources -t "user" --output-format=json \
     | jq -r --arg user_id "$user_id" \
-         '(.resources // [])[] |
-          select(.resource.id.resource == $user_id) |
-          (.resource.annotations[]? | select(."@type" == "type.googleapis.com/c1.connector.v2.UserTrait")) as $trait |
-          if $trait != null and $trait.status != null then
-            $trait.status
-          else
-            "unknown"
-          end')
-  # Extract just the status value if it's JSON, otherwise return as-is
-  echo "$status" | jq -r '.status // empty' 2>/dev/null || echo "$status"
+         '(.resources // [])[]
+          | select(.resource.id.resource == $user_id)
+          | .resource as $r
+          # Resource-level status (newer baton-sdk): Status_ResourceStatus enum.
+          | ($r.status.status // null) as $resStatus
+          # Deprecated trait-level status: UserTrait_Status_Status enum.
+          | ((
+              $r.annotations[]?
+              | select(."@type" == "type.googleapis.com/c1.connector.v2.UserTrait")
+              | .status.status
+            ) // null) as $traitStatus
+          # Normalize "RESOURCE_STATUS_*" to the trait-form "STATUS_*".
+          | (if $resStatus == null then null else ($resStatus | sub("^RESOURCE_"; "")) end) as $resNorm
+          | if   ($resNorm    != null and $resNorm    != "STATUS_UNSPECIFIED") then $resNorm
+            elif ($traitStatus != null and $traitStatus != "STATUS_UNSPECIFIED") then $traitStatus
+            else "unknown"
+            end'
 }
 
 # Function to check if user is enabled

--- a/actions/account-status-lifecycle-test/account-status-lifecycle-test.sh
+++ b/actions/account-status-lifecycle-test/account-status-lifecycle-test.sh
@@ -45,14 +45,16 @@ source "${SCRIPT_DIR}/../_helpers/sleep.sh"
 # Status can live in one of two places depending on the baton-sdk version the
 # connector was built with:
 #   * Resource-level: .resource.status.status, using the Status_ResourceStatus
-#     enum (e.g. "RESOURCE_STATUS_ENABLED"). This is where newer SDKs put it.
+#     enum (e.g. "RESOURCE_STATUS_ENABLED"). baton-sdk v0.19.0 moved status here
+#     from the trait (ConductorOne/baton-sdk#996) and deprecated the trait field.
 #   * Deprecated trait-level: the UserTrait annotation's .status.status, using
-#     the UserTrait_Status_Status enum (e.g. "STATUS_ENABLED").
+#     the UserTrait_Status_Status enum (e.g. "STATUS_ENABLED"). Used by
+#     connectors built against baton-sdk < v0.19.0.
 #
 # We read both and prefer the resource-level value, normalizing it to the
 # trait-form ("RESOURCE_STATUS_ENABLED" -> "STATUS_ENABLED") so the rest of the
-# script keeps comparing against STATUS_ENABLED/STATUS_DISABLED. Newer SDKs
-# default the deprecated trait status to STATUS_ENABLED when it isn't set
+# script keeps comparing against STATUS_ENABLED/STATUS_DISABLED. On v0.19.0+ the
+# deprecated trait status defaults to STATUS_ENABLED when it isn't set
 # explicitly, so the trait value alone is unreliable and is only used as a
 # fallback when no resource-level status is present.
 get_user_status() {


### PR DESCRIPTION
## Problem

The `account-status-lifecycle-test` action reads user status **only** from the deprecated `UserTrait` annotation (`UserTrait_Status_Status`, e.g. `STATUS_ENABLED`).

Recent `baton-sdk` versions moved status to a **resource-level** attribute (`Status_ResourceStatus`, e.g. `RESOURCE_STATUS_ENABLED`). When a connector migrates to `WithResourceStatus(...)` and sets only the resource-level status:

- The SDK mirrors trait → resource, but **not** resource → trait.
- `NewUserTrait` **defaults an unset trait status to `STATUS_ENABLED`**.

So the test always reads `STATUS_ENABLED` from the trait, and disable verifications fail even when the account was correctly disabled:

```
User 2 current status: STATUS_ENABLED
✗ User is not disabled as expected
```

(Hit while migrating `baton-looker` off the deprecated trait options — the connector builds and disables correctly, but this shared test couldn't observe the resource-level status.)

## Fix

`get_user_status` now reads **both** locations and:

1. Prefers the resource-level `resource.status.status`, normalizing `RESOURCE_STATUS_*` → the trait form `STATUS_*`.
2. Falls back to the deprecated trait `status.status` only when no resource-level status is present.
3. Treats `*_UNSPECIFIED` as absent, so the unreliable defaulted trait value never masks a real resource-level status.

Downstream comparisons (`is_user_enabled`, summaries) are unchanged — they still compare against `STATUS_ENABLED` / `STATUS_DISABLED`.

This keeps the action compatible with connectors built against **any** baton-sdk version (trait-only, resource-only, or both).

## Validation

Verified the jq logic against all shapes:

| Scenario | Result |
|---|---|
| New SDK: resource DISABLED, trait defaulted ENABLED | `STATUS_DISABLED` ✅ (was `STATUS_ENABLED` ❌) |
| New SDK: resource ENABLED, trait defaulted ENABLED | `STATUS_ENABLED` ✅ |
| Old connector: trait DISABLED, no resource status | `STATUS_DISABLED` ✅ |
| Old connector: trait ENABLED, no resource status | `STATUS_ENABLED` ✅ |
| Resource UNSPECIFIED + trait DISABLED | `STATUS_DISABLED` ✅ |
| Nothing set | `unknown` ✅ |

`bash -n` passes on the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)