### PR TITLE
fix(pr-review): use -F not -f for summary comment stdin body

### DIFF
--- a/.github/actions/pr-review/prompts/base-pr-review.md
+++ b/.github/actions/pr-review/prompts/base-pr-review.md
@@ -150,12 +150,14 @@ Prefix: `🔴 Security:` / `🟠 Bug:` / `🟡 Suggestion:`. Keep to 2-3 sentenc
 **Summary comment:** Pass the body via stdin with a heredoc, using `-F body=@-` — NOT
 `-f body=...`. `-f` is a raw string field and does not support `@filename`/`@-` stdin
 magic, so `-f body=@-` would literally set the comment body to the two characters `@-`.
-`-F` is the typed field flag that does support it. If `summary_comment_id` is set, update
+`-F` is the typed field flag that does support it. Use an unusual heredoc terminator —
+never a plain word like `EOF` — so a line of ordinary review body text can never
+collide with it and truncate the body early. If `summary_comment_id` is set, update
 that issue comment with:
 ```
-gh api -X PATCH repos/<repository>/issues/comments/<summary_comment_id> -F body=@- <<'BODY_EOF'
+gh api -X PATCH repos/<repository>/issues/comments/<summary_comment_id> -F body=@- <<'GH_PR_REVIEW_BODY_EOF__'
 ...
-BODY_EOF
+GH_PR_REVIEW_BODY_EOF__
 ```
 If it is not set, create one the same way against
 `repos/<repository>/issues/<pr_number>/comments`.

--- a/.github/actions/pr-review/prompts/base-pr-review.md
+++ b/.github/actions/pr-review/prompts/base-pr-review.md
@@ -147,10 +147,18 @@ posting a summary, inline comments, or review verdict.
 **Inline comments:** Post on specific lines using `mcp__github_inline_comment__create_inline_comment`.
 Prefix: `🔴 Security:` / `🟠 Bug:` / `🟡 Suggestion:`. Keep to 2-3 sentences.
 
-**Summary comment:** If `summary_comment_id` is set, update that issue comment with
-`gh api -X PATCH repos/<repository>/issues/comments/<summary_comment_id> -f body=...`.
-If it is not set, create one with
-`gh api repos/<repository>/issues/<pr_number>/comments -f body=...`.
+**Summary comment:** Pass the body via stdin with a heredoc, using `-F body=@-` — NOT
+`-f body=...`. `-f` is a raw string field and does not support `@filename`/`@-` stdin
+magic, so `-f body=@-` would literally set the comment body to the two characters `@-`.
+`-F` is the typed field flag that does support it. If `summary_comment_id` is set, update
+that issue comment with:
+```
+gh api -X PATCH repos/<repository>/issues/comments/<summary_comment_id> -F body=@- <<'BODY_EOF'
+...
+BODY_EOF
+```
+If it is not set, create one the same way against
+`repos/<repository>/issues/<pr_number>/comments`.
 Do not delete existing summary comments before the new review has been posted.
 
 Use this template for the summary body. The heading must be exactly the `summary_heading`


### PR DESCRIPTION
## Summary
- The review prompt told Claude to post the summary comment with `gh api ... -f body=...`. `gh`'s `@filename`/`@-` stdin magic only works with `-F` (typed field), not `-f` (raw string) — so when Claude tried to stream the multi-line review body via `-f body=@-`, `gh` set the comment body to the literal two-character string `@-` instead.
- Confirmed this happened for real on `baton-aws` (#132, #137), `baton-okta`, `baton-servicenow`, `baton-sql`, and `baton-google-workspace` — all posted a bot comment whose entire body is `@-`.
- Fix: instruct `-F body=@- <<'BODY_EOF' ... BODY_EOF` (heredoc into a typed field), which does support stdin.

## Test plan
- [x] Reproduced the exact bug and the fix against GitHub's stateless `POST /markdown` endpoint (no repo side effects): `-f text=@-` rendered as `<p>@-</p>`; `-F text=@-` rendered the actual heredoc content.
- [ ] Confirm on the next real connector PR that the summary comment posts full review content instead of `@-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)