### PR TITLE
Use claude-opus-5 for the pr-review reviewer model

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -94,7 +94,7 @@ runs:
       include_fix_links: true
       use_sticky_comment: true
       allowed_bots: "*"
-      claude_args: --model claude-opus-4-8 --max-turns 100 --allowedTools "Read,Glob,Grep,Skill,Task,mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+      claude_args: --model claude-opus-5 --max-turns 100 --allowedTools "Read,Glob,Grep,Skill,Task,mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
       prompt: ${{ env.REVIEW_PROMPT }}
   - name: Upload review context artifacts
     if: always()


### PR DESCRIPTION
## Why

The pr-review reviewer runs on a pinned model. This moves it to `claude-opus-5` so reviews use the newer Opus.

## What this changes

Single-token change to `claude_args` in the pr-review composite action: `--model claude-opus-4-8` → `--model claude-opus-5`. No other behavior changed.