### PR TITLE
Raise pr-review job timeout to 30 minutes

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -87,7 +87,7 @@ runs:
         echo "${DELIM}"
       } >> "${GITHUB_ENV}"
   - name: Run Claude PR Review
-    uses: anthropics/claude-code-action@661a6fefbd0569ef35809da16775508ab1937862
+    uses: anthropics/claude-code-action@9db594c7a0e82298c121c18b7f08aa1579ce7341  # v1.0.185
     with:
       anthropic_api_key: ${{ inputs.anthropic_api_key }}
       github_token: ${{ inputs.github_token }}

--- a/.github/workflows/general-pr-review.yaml
+++ b/.github/workflows/general-pr-review.yaml
@@ -42,4 +42,4 @@ jobs:
           pr_number: ${{ github.event.pull_request.number }}
           head_sha: ${{ github.event.pull_request.head.sha }}
           review_prompt: general
-    timeout-minutes: 20
+    timeout-minutes: 30

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -48,4 +48,4 @@ jobs:
           pr_number: ${{ github.event.pull_request.number }}
           head_sha: ${{ github.event.pull_request.head.sha }}
           review_prompt: ${{ inputs.review_prompt || 'connector' }}
-    timeout-minutes: 15
+    timeout-minutes: 30


### PR DESCRIPTION
## Why

The reviewer model is now `claude-opus-5`, which runs longer per review than opus-4-8 (and the automatic cybersecurity→opus-4.8 safety fallback can stack a second run into the same job). On the ductone side the same model bump drove judge PR-review timeouts from 0/809 runs to 20/191 (10.5%) against a 15-minute cap — cancelled mid-review, surfacing as a "did not finish in time … not a verdict" notice rather than a real verdict. This raises the caps here before the same regression shows up.

## What this changes

Raises `timeout-minutes` to 30 on both PR-review reusable-workflow jobs: `pr-review.yaml` (15→30) and `general-pr-review.yaml` (20→30). Trade-off: a longer-running or wedged review now uses up to 30 runner-minutes before being cut off.